### PR TITLE
Add syntax-highlighting for python string literals (#2)

### DIFF
--- a/styles/syntax/python.less
+++ b/styles/syntax/python.less
@@ -15,6 +15,12 @@
     }
   }
   
+  .syntax--meta {
+    &.syntax--fstring .syntax--storage {
+      color: @hue-3;
+    }
+  }
+
   .syntax--punctuation {
     &.syntax--section.syntax--function.syntax--begin {
       color: @mono-1;

--- a/styles/syntax/python.less
+++ b/styles/syntax/python.less
@@ -14,12 +14,6 @@
       color: @hue-3;
     }
   }
-  
-  .syntax--meta {
-    &.syntax--fstring .syntax--storage {
-      color: @hue-3;
-    }
-  }
 
   .syntax--punctuation {
     &.syntax--section.syntax--function.syntax--begin {
@@ -30,6 +24,9 @@
   .syntax--string {
     &.syntax--quoted.syntax--double.syntax--block.syntax--sql {
       color: @mono-3;
+    }
+    .syntax--storage {
+      color: @hue-3;
     }
   }
 


### PR DESCRIPTION
Fixes #2 by add Python f-string syntax-highlighting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tterb/atomic-monokai-pro-syntax/3)
<!-- Reviewable:end -->
